### PR TITLE
Fix aliased fields and embedded children

### DIFF
--- a/lib/saxomattic.rb
+++ b/lib/saxomattic.rb
@@ -49,7 +49,8 @@ module Saxomattic
   module ClassMethods
     def attribute(*args)
       options = args.extract_options!
-      field = args.first
+      sax_field = args.first
+      attr_field = options[:as] || sax_field
 
       # If you want to setup a default set of elements, you can!
       # :default => [ true, false, false, true ]
@@ -57,28 +58,28 @@ module Saxomattic
         options.merge!(:default => [])
       end
 
-      _active_attr_attribute(field, _active_attr_attributes(options.dup))
+      _active_attr_attribute(attr_field, _active_attr_attributes(options.dup))
 
       case
       when options[:ancestor] then
-        _sax_machine_ancestor(field, _sax_machine_attributes(options.dup))
+        _sax_machine_ancestor(sax_field, _sax_machine_attributes(options.dup))
       when options[:attribute] then
-        _sax_machine_attribute(field, _sax_machine_attributes(options.dup))
+        _sax_machine_attribute(sax_field, _sax_machine_attributes(options.dup))
       when options[:elements] then
-        _sax_machine_elements(field, _sax_machine_attributes(options.dup))
+        _sax_machine_elements(sax_field, _sax_machine_attributes(options.dup))
       when options[:value] then
-        _sax_machine_value(field, _sax_machine_attributes(options.dup))
+        _sax_machine_value(sax_field, _sax_machine_attributes(options.dup))
       else # Default state is an element
-        _sax_machine_element(field, _sax_machine_attributes(options.dup))
+        _sax_machine_element(sax_field, _sax_machine_attributes(options.dup))
       end
     end
 
     def _active_attr_attributes(options_hash = {})
-      options_hash.slice!(::Saxomattic::ACTIVE_ATTR_ATTRIBUTES)
+      options_hash.slice(*::Saxomattic::ACTIVE_ATTR_ATTRIBUTES)
     end
 
     def _sax_machine_attributes(options_hash = {})
-      options_hash.slice!(::Saxomattic::SAX_MACHINE_ATTRIBUTES)
+      options_hash.slice(*::Saxomattic::SAX_MACHINE_ATTRIBUTES)
     end
   end
 

--- a/spec/saxomattic_spec.rb
+++ b/spec/saxomattic_spec.rb
@@ -16,6 +16,12 @@ class SaxTesterEmbedded
   attribute :embedception, :class => SaxTesterEmbedception
 end
 
+class SaxTesterChild
+  include Saxomattic
+
+  attribute :name
+end
+
 class SaxTesterSomething
   include Saxomattic
 
@@ -25,6 +31,7 @@ class SaxTesterSomething
   attribute :date, :type => Date
   attribute :datetime, :type => DateTime
   attribute :embedded, :elements => true, :class => SaxTesterEmbedded
+  attribute :child, :as => :children, :elements => true, :class => SaxTesterChild
   attribute :CAPITALIZATION, :as => :capitalization
 end
 
@@ -46,6 +53,14 @@ describe ::Saxomattic do
         <embed>#{embedded_message}</embed>
         <embedception type="#{embedception_type}">#{embedception_value}</embedception>
       </embedded>
+      <parent>
+        <child>
+          <name>John</name>
+        </child>
+        <child>
+          <name>Paul</name>
+        </child>
+      </parent>
       <date>#{Date.today}</date>
       <foo>2</foo>
       <CAPITALIZATION>cap</CAPITALIZATION>
@@ -83,6 +98,12 @@ describe ::Saxomattic do
       subject.embedded.first.embedception.type.should eq(embedception_type)
       subject.embedded.first.embedception.value.should eq(embedception_value)
       subject.embedded.first.embedception.not_even_used?.should be_false
+    end
+
+    it "extracts multiple children from a parent element" do
+      subject.children.size.should eq 2
+      subject.children.first.name.should eq "John"
+      subject.children.last.name.should eq "Paul"
     end
   end
 


### PR DESCRIPTION
When passing an `:as` option, active_attr used the original field name rather
than the aliased one.

ActiveSupport's Hash.slice/slice! methods expect an argument list rather
than an array.

Hash.slice! returns a hash of the key/value pairs that were _removed_
rather than the modified hash itself.
