### PR TITLE
Add support for ActiveAttr typecasters

### DIFF
--- a/lib/saxomattic.rb
+++ b/lib/saxomattic.rb
@@ -8,7 +8,8 @@ require "active_support/core_ext/string/conversions"
 module Saxomattic
   ACTIVE_ATTR_ATTRIBUTES = [
     :default,
-    :type
+    :type,
+    :typecaster
   ].freeze
 
   SAX_MACHINE_ATTRIBUTES = [
@@ -23,7 +24,7 @@ module Saxomattic
     klass.extend(HookManagementMethods)
     klass.__send__(:include, ::SAXMachine)
     klass._capture_sax_machine_methods(klass)
-    # Keep these in this order as the initialize call in 
+    # Keep these in this order as the initialize call in
     # sax-machine doesn't `super` so we need it to be last in
     klass.__send__(:include, ::ActiveAttr::Model)
     klass._capture_active_attr_methods(klass)

--- a/saxomattic.gemspec
+++ b/saxomattic.gemspec
@@ -24,6 +24,6 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "nokogiri", ">= 1.6"
   gem.add_development_dependency "pry"
   gem.add_development_dependency "rake"
-  gem.add_development_dependency "rspec"
+  gem.add_development_dependency "rspec", ">= 3.4"
   gem.add_development_dependency "simplecov"
 end

--- a/saxomattic.gemspec
+++ b/saxomattic.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "activesupport"
   gem.add_dependency "sax-machine"
 
+  gem.add_development_dependency "nokogiri", ">= 1.6"
   gem.add_development_dependency "pry"
   gem.add_development_dependency "rake"
   gem.add_development_dependency "rspec"

--- a/spec/saxomattic_spec.rb
+++ b/spec/saxomattic_spec.rb
@@ -27,7 +27,7 @@ class SaxTesterSomething
 
   attribute :baz
   attribute :foo, :type => Integer
-  attribute :iso_8701, :type => Date
+  attribute :iso_8701, :typecaster => ActiveAttr::Typecasting::DateTypecaster.new
   attribute :date, :type => Date
   attribute :datetime, :type => DateTime
   attribute :embedded, :elements => true, :class => SaxTesterEmbedded, :default => []
@@ -36,7 +36,7 @@ class SaxTesterSomething
 end
 
 describe ::Saxomattic do
-
+  let(:iso_8701) { "2013-01-13" }
   let(:embedded_message) { "HERE!" }
   let(:embedception_type) { "TYPE" }
   let(:embedception_value) { "VALUE" }
@@ -46,7 +46,7 @@ describe ::Saxomattic do
     <<-XML
     <test>
       <baz>#{baz}</baz>
-      <iso_8701>2013-01-13</iso_8701>
+      <iso_8701>#{iso_8701}</iso_8701>
       <datetime>#{DateTime.now}</datetime>
       <embedded>
         <foo>2</foo>
@@ -82,6 +82,11 @@ describe ::Saxomattic do
     it "typecasts Dates when declared with type => Date" do
       expect(subject.date).to be_a(Date)
       expect(subject.date).to eq(Date.today)
+    end
+
+    it "typecasts Dates when declared with typecaster => ActiveAttr::Typecasting::DateTypecaster" do
+      expect(subject.iso_8701).to be_a(Date)
+      expect(subject.iso_8701).to eq(iso_8701.to_date)
     end
 
     it "embedded" do

--- a/spec/saxomattic_spec.rb
+++ b/spec/saxomattic_spec.rb
@@ -71,39 +71,39 @@ describe ::Saxomattic do
   subject { SaxTesterSomething.parse(xml) }
 
   it "extracts elements when declared as attribute" do
-    subject.baz.should eq(baz)
+    expect(subject.baz).to eq(baz)
   end
 
   context "TypeCasting" do
     it "typecasts integers when declared with type => Integer" do
-      subject.foo.should eq(foo)
+      expect(subject.foo).to eq(foo)
     end
 
     it "typecasts Dates when declared with type => Date" do
-      subject.date.should be_a(Date)
-      subject.date.should eq(Date.today)
+      expect(subject.date).to be_a(Date)
+      expect(subject.date).to eq(Date.today)
     end
 
     it "embedded" do
-      subject.embedded.should be_a(Array)
-      subject.embedded.first.embed.should eq(embedded_message)
+      expect(subject.embedded).to be_a(Array)
+      expect(subject.embedded.first.embed).to eq(embedded_message)
     end
 
     it "typecasts embedded fields" do
-      subject.embedded.first.foo.should eq(foo)
+      expect(subject.embedded.first.foo).to eq(foo)
     end
 
     it "embeds values further" do
-      subject.embedded.first.embedception?.should be_true
-      subject.embedded.first.embedception.type.should eq(embedception_type)
-      subject.embedded.first.embedception.value.should eq(embedception_value)
-      subject.embedded.first.embedception.not_even_used?.should be_false
+      expect(subject.embedded.first.embedception?).to be true
+      expect(subject.embedded.first.embedception.type).to eq(embedception_type)
+      expect(subject.embedded.first.embedception.value).to eq(embedception_value)
+      expect(subject.embedded.first.embedception.not_even_used?).to be false
     end
 
     it "extracts multiple children from a parent element" do
-      subject.children.size.should eq 2
-      subject.children.first.name.should eq "John"
-      subject.children.last.name.should eq "Paul"
+      expect(subject.children.size).to eq 2
+      expect(subject.children.first.name).to eq "John"
+      expect(subject.children.last.name).to eq "Paul"
     end
   end
 


### PR DESCRIPTION
In addition to accepting a `:type` option, ActiveAttr also accepts a `:typecaster` option that can be used by custom typecasts.

Also add Nokogiri as a development dependency and upgrade to RSpec 3.4.
